### PR TITLE
Default language issue with aria-label attribute

### DIFF
--- a/xhr_grabber.py
+++ b/xhr_grabber.py
@@ -27,6 +27,7 @@ def get_m3u8(space_url):
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument('--headless')
         chrome_options.add_argument('--mute-audio')
+        chrome_options.add_argument('--lang=en-US')
         chrome_options.add_experimental_option('excludeSwitches', ['enable-logging'])
         driver = webdriver.Chrome(service=Service(ChromeDriverManager(log_level=0).install()), options=chrome_options)
     except WebDriverException as driverError:


### PR DESCRIPTION
Since the browser language changes depending on the region, the --lang option is used to fix the language to English.
This will fix aria-label to English.